### PR TITLE
Fix: Image Rendering in Screenshots

### DIFF
--- a/src/components/DetailedStats.tsx
+++ b/src/components/DetailedStats.tsx
@@ -1,7 +1,14 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RepoStats, ContributionStats } from '../types/github';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
 
 interface DetailedStatsProps {
   repoStats: RepoStats;
@@ -28,12 +35,12 @@ export const DetailedStats: React.FC<DetailedStatsProps> = ({
     });
   }, [contributionStats?.contributionsByMonth, t]);
 
-  const dailyData = Object.entries(contributionStats.contributionsByDay || {}).map(
-    ([day, count]) => ({
-      day,
-      contributions: count,
-    })
-  );
+  const dailyData = Object.entries(
+    contributionStats.contributionsByDay || {}
+  ).map(([day, count]) => ({
+    day,
+    contributions: count,
+  }));
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 mt-6">
@@ -179,10 +186,15 @@ export const DetailedStats: React.FC<DetailedStatsProps> = ({
           </h3>
           <div className="text-center">
             <div className="text-2xl font-bold text-blue-500">
-              {t(`common.weekdays.full.${contributionStats.mostProductiveDay?.day}`)}
+              {t(
+                `common.weekdays.full.${
+                  contributionStats.mostProductiveDay?.day || 'monday'
+                }`
+              )}
             </div>
             <div className="text-sm text-gray-600 dark:text-gray-400">
-              {contributionStats.mostProductiveDay?.contributions} {t('developers.contributions')}
+              {contributionStats.mostProductiveDay?.contributions}{' '}
+              {t('developers.contributions')}
             </div>
           </div>
         </div>
@@ -203,4 +215,4 @@ export const DetailedStats: React.FC<DetailedStatsProps> = ({
       </div>
     </div>
   );
-}; 
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  img {
+    @apply inline-block;
+  }
+}


### PR DESCRIPTION
**Problem**
Images within components `GithubCard` were experiencing layout or rendering issues (misalignment) when exported as a PNG. [#12](https://github.com/Tiavina22/dash/issues/12)

**Solution Implemented:**
This PR introduces a global base style for all `<img>` elements, setting their display property to `inline-block`. This is achieved by adding `img { @apply inline-block; }` within the `@layer base` of our Tailwind CSS configuration.

**Source of Solution:**
- [Stack Overflow Answer](https://stackoverflow.com/a/75010048)